### PR TITLE
Add missing option `limit` and  optimize the promise

### DIFF
--- a/app/steps/buildProxyReq.js
+++ b/app/steps/buildProxyReq.js
@@ -10,15 +10,13 @@ function buildProxyReq(Container) {
   var parseBody = (!options.parseReqBody) ? Promise.resolve(null) : requestOptions.bodyContent(ctx, options);
   var createReqOptions = requestOptions.create(ctx, options, host);
 
-  return new Promise(function(resolve) {
-    Promise
+  return Promise
     .all([parseBody, createReqOptions])
     .then(function(responseArray) {
       Container.proxy.bodyContent = responseArray[0];
       Container.proxy.reqBuilder = responseArray[1];
-      resolve(Container);
+      return Container;
     });
-  });
 }
 
 module.exports = buildProxyReq;

--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -28,7 +28,8 @@ function resolveOptions(options) {
     https: options.https,
     port: options.port,
     reqAsBuffer: options.reqAsBuffer,
-    timeout: options.timeout
+    timeout: options.timeout,
+    limit: options.limit,
   };
 }
 

--- a/test/bodyEncoding.js
+++ b/test/bodyEncoding.js
@@ -21,6 +21,7 @@ describe('body encoding', function() {
                '0d0a2db4000000004' +
                '9454e44ae426082';
   var pngData = new Buffer(pngHex, 'hex');
+  var largePngData = new Buffer(pngHex.repeat(100000), 'hex'); // 6.7MB
 
   it('allow raw data', function(done) {
     var filename = os.tmpdir() + '/koa-better-http-proxy-test-' + (new Date()).getTime() + '-png-transparent.png';
@@ -54,6 +55,49 @@ describe('body encoding', function() {
 
   });
 
+  // In this case, the package `raw-body` will print error stack which does not mater.
+  it('should get 413 by posting file which is larger than 1mb without setting limit', function(done) {
+    var filename = os.tmpdir() + '/koa-better-http-proxy-test-' + (new Date()).getTime() + '-png-transparent.png';
+    var app = new Koa();
+    app.use(proxy('localhost:8109', {
+    }));
+    fs.writeFile(filename, largePngData, function(err) {
+      if (err) { throw err; }
+      agent(app.callback())
+        .post('/post')
+        .attach('image', filename)
+        .expect(413)
+        .end(function(err) {
+          fs.unlink(filename);
+          assert(err === null);
+          if (err) { return done(err); }
+          done();
+        });
+    });
+  });
+
+  it('should not fail on large limit', function(done) {
+    var filename = os.tmpdir() + '/koa-better-http-proxy-test-' + (new Date()).getTime() + '-png-transparent.png';
+    var app = new Koa();
+    app.use(proxy('localhost:8109', {
+      // This case `parseReqBody` should not be set to false,
+      limit: '20gb',
+    }));
+    fs.writeFile(filename, largePngData, function(err) {
+      if (err) { throw err; }
+      agent(app.callback())
+        .post('/post')
+        .attach('image', filename)
+        .expect(200)
+        .end(function(err) {
+          fs.unlink(filename);
+          assert(err === null);
+          if (err) { return done(err); }
+          done();
+        });
+    });
+  });
+
   describe('when user sets parseReqBody', function() {
 
     it('should not parse body', function(done) {
@@ -85,6 +129,9 @@ describe('body encoding', function() {
       });
     });
 
+    // This test is unnecessary, because when `parseReqBody` is set to `false`,
+    // bodyContent will not be parsed, thus the `limit` options will not be used.
+    // see app/steps/buildProxyReq.js#L10
     it('should not fail on large limit', function(done) {
       var filename = os.tmpdir() + '/koa-better-http-proxy-test-' + (new Date()).getTime() + '-png-transparent.png';
       var app = new Koa();

--- a/test/bodyEncoding.js
+++ b/test/bodyEncoding.js
@@ -129,34 +129,6 @@ describe('body encoding', function() {
       });
     });
 
-    // This test is unnecessary, because when `parseReqBody` is set to `false`,
-    // bodyContent will not be parsed, thus the `limit` options will not be used.
-    // see app/steps/buildProxyReq.js#L10
-    it('should not fail on large limit', function(done) {
-      var filename = os.tmpdir() + '/koa-better-http-proxy-test-' + (new Date()).getTime() + '-png-transparent.png';
-      var app = new Koa();
-      app.use(proxy('localhost:8109', {
-        parseReqBody: false,
-        limit: '20gb',
-      }));
-      fs.writeFile(filename, pngData, function(err) {
-        if (err) { throw err; }
-        agent(app.callback())
-          .post('/post')
-          .attach('image', filename)
-          .end(function(err) {
-            fs.unlink(filename);
-            assert(err === null);
-            // This test is both broken and I think unnecessary.
-            // Its broken because http.bin no longer supports /post, but this test assertion is based on the old
-            // httpbin behavior.
-            // The assertion in the proxyReqOptDecorator above verifies the test title.
-            //var response = new Buffer(res.body.attachment.data).toString('base64');
-            //assert(response.indexOf(pngData.toString('base64')) >= 0, 'response should include original raw data');
-            done(err);
-          });
-      });
-    });
   });
 
   describe('when user sets reqBodyEncoding', function() {


### PR DESCRIPTION
1. According the documentation, it does not work. Finally I found that the option was missing in the module lib/resolveOptions.

2. With the original version,  if the request gets an error(for example 413), the request will be hang up, because the rejection was not rejected out.

Please consider it.Thanks!