### PR TITLE
correct declaration file

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,33 +1,36 @@
 import * as koa from 'koa';
 import * as http from 'http';
 
-export interface IOptions {
-  headers?: { [key: string]: any},
-  https?: boolean,
-  limit?: string,
-  parseReqBody?: boolean,
-  port?: number,
-  preserveHostHdr?: boolean,
-  preserveReqSession?: boolean,
-  reqAsBuffer?: boolean,
-  reqBodyEncoding?: string | null,
-  timeout?: number,
-  filter?(ctx: koa.Context): boolean,
-  proxyReqBodyDecorator?(bodyContent: string, ctx: koa.Context): string | Promise<string>,
-  proxyReqOptDecorator?(proxyReqOpts: IRequestOption, ctx: koa.Context): IRequestOption | Promise<IRequestOption>,
-  proxyReqPathResolver?(ctx: koa.Context): string | Promise<string>,
-  userResDecorator?(proxyRes: http.IncomingMessage, proxyResData: string | Buffer, ctx: koa.Context): string | Buffer | Promise<string> | Promise<Buffer>,
+declare function koaHttpProxy(host: string, options: koaHttpProxy.IOptions): koa.Middleware;
+
+declare namespace koaHttpProxy {
+  export interface IOptions {
+    headers?: { [key: string]: any },
+    https?: boolean,
+    limit?: string,
+    parseReqBody?: boolean,
+    port?: number,
+    preserveHostHdr?: boolean,
+    preserveReqSession?: boolean,
+    reqAsBuffer?: boolean,
+    reqBodyEncoding?: string | null,
+    timeout?: number,
+    filter?(ctx: koa.Context): boolean,
+    proxyReqBodyDecorator?(bodyContent: string, ctx: koa.Context): string | Promise<string>,
+    proxyReqOptDecorator?(proxyReqOpts: IRequestOption, ctx: koa.Context): IRequestOption | Promise<IRequestOption>,
+    proxyReqPathResolver?(ctx: koa.Context): string | Promise<string>,
+    userResDecorator?(proxyRes: http.IncomingMessage, proxyResData: string | Buffer, ctx: koa.Context): string | Buffer | Promise<string> | Promise<Buffer>,
+  }
+
+  export interface IRequestOption {
+    hostname: string,
+    port: number,
+    headers: { [key: string]: any },
+    method: string,
+    path: string,
+    bodyContent: string | Buffer,
+    params: any,
+  }
 }
 
-export interface IRequestOption {
-  hostname: string,
-  port: number,
-  headers: { [key: string]: any},
-  method: string,
-  path: string,
-  bodyContent: string | Buffer,
-  params: any,
-}
-
-export as namespace KoaHttpProxy;
-export default function KoaHttpProxy(host: string, options: IOptions): koa.Middleware;
+export = koaHttpProxy


### PR DESCRIPTION
Recently, I start to learn Typescript and try to refactor some of my previous pure javascript libraries.When I import this module, I was happy that there was already a `types.d.ts` file, which means I need not to install @types package. But soon I found that, the `types.d.ts` file did not work as expected.

The last line:
```typescript
export default function KoaHttpProxy(host: string, options: IOptions): koa.Middleware;
```
means that, the lib is a ES6-style module which is not actually.
And this is not necessary:
```typescript
export as namespace KoaHttpProxy;
```
Finally, I wrote a new one according to the [official template](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html), and it did work(both compilation and runtime) like this:
```typescript
import * as koaHttpProxy from 'koa-better-http-proxy'
// import koaHttpProxy = require('koa-better-http-proxy') // this style works too

koaHttpProxy('someHost', {...})
```

I am a newer for Typescript, still learning. Thanks.