### PR TITLE
Fix that some response cause decompress fail

### DIFF
--- a/app/steps/decorateUserRes.js
+++ b/app/steps/decorateUserRes.js
@@ -9,7 +9,15 @@ function isResGzipped(res) {
 
 function zipOrUnzip(method) {
   return function(rspData, res) {
-    return (isResGzipped(res)) ? zlib[method](rspData) : rspData;
+    // Be less strict when decoding compressed responses, since sometimes
+    // servers send slightly invalid responses that are still accepted
+    // by common browsers.
+    // Always using Z_SYNC_FLUSH is what cURL does.
+    var zlibOptions = {
+        flush: zlib.Z_SYNC_FLUSH,
+        finishFlush: zlib.Z_SYNC_FLUSH
+    };
+    return (isResGzipped(res)) ? zlib[method](rspData, zlibOptions) : rspData;
   };
 }
 


### PR DESCRIPTION
[2018-09-07T12:27:17.742] [FATAL] mapping - { Error: unexpected end of file
    at Zlib.zlibOnError [as onerror] (zlib.js:153:17)
    at processChunkSync (zlib.js:481:12)
    at zlibBufferSync (zlib.js:139:12)
    at Object.gunzipSync (zlib.js:695:14)
    at /root/mockingbirds/65003/mockingbird/node_modules/koa-better-http-proxy/app/steps/decorateUserRes.js:12:46

Due to this problem.