### PR TITLE
Add connectTimeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,24 @@ app.use(proxy('httpbin.org', {
 }));
 ```
 
+#### connectTimeout
+
+By default, node does not express a timeout on connections.
+Use connectTimeout option to impose a specific timeout on the inital connection. (`connect` for http requests and `secureConnect` for https)
+This is useful if there are dns, network issues, or if you are uncertain if the destination is reachable.
+Timed-out requests will respond with 504 status code and a X-Timeout-Reason header.
+
+```js
+app.use(proxy('httpbin.org', {
+  connectTimeout: 2000  // in milliseconds, two seconds
+}));
+```
+
 
 #### timeout
 
 By default, node does not express a timeout on connections.
-Use timeout option to impose a specific timeout.
+Use timeout option to impose a specific timeout. This includes the time taken to make the connection and can be used with or without `connectTimeout`.
 Timed-out requests will respond with 504 status code and a X-Timeout-Reason header.
 
 ```js

--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -44,6 +44,7 @@ function parseHost(Container) {
   return {
     host: parsed.hostname,
     port: parsed.port || (ishttps ? 443 : 80),
+    isSecure: ishttps,
     module: ishttps ? https : http,
   };
 }

--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -28,6 +28,7 @@ function resolveOptions(options) {
     https: options.https,
     port: options.port,
     reqAsBuffer: options.reqAsBuffer,
+    connectTimeout: options.connectTimeout,
     timeout: options.timeout,
     limit: options.limit,
   };

--- a/test/connectTimeout.js
+++ b/test/connectTimeout.js
@@ -1,0 +1,97 @@
+var Koa = require('koa');
+var agent = require('supertest').agent;
+var proxy = require('../');
+var proxyTarget = require('./support/proxyTarget');
+
+describe('honors connectTimeout option', function() {
+  'use strict';
+
+  var other, http;
+  beforeEach(function() {
+    http = new Koa();
+    other = proxyTarget(8080, 1000, [{
+      method: 'get',
+      path: '/',
+      fn: function(_, res) { res.sendStatus(200); }
+    }]);
+  });
+
+  afterEach(function() {
+    other.close();
+  });
+
+  function assertSuccess(server, done) {
+    agent(server.callback())
+      .get('/')
+      .expect(200)
+      .end(function(err) {
+        if (err) {
+          return done(err);
+        }
+        done();
+      });
+  }
+
+  function assertConnectionTimeout(server, time, done) {
+    agent(server.callback())
+      .get('/')
+      .expect(504)
+      .expect('X-Timout-Reason', 'koa-better-http-proxy timed out your request after ' + time + 'ms.')
+      .end(function(err) {
+        if (err) {
+          return done(err);
+        }
+        done();
+      });
+  }
+
+  describe('when connectTimeout option is set lower than server connect time', function() {
+    it('should fail with CONNECTION TIMEOUT', function(done) {
+      http.use(proxy('http://127.0.0.0', {
+        connectTimeout: 50,
+      }));
+
+      assertConnectionTimeout(http, 50, done);
+    });
+  });
+
+  describe('when connectTimeout option is set higher than server connect time', function() {
+    it('should succeed', function(done) {
+      http.use(proxy('http://localhost:8080', {
+        connectTimeout: 50,
+      }));
+
+      assertSuccess(http, done);
+    });
+  });
+
+  describe('when timeout option is also used', function() {
+    it('should fail with CONNECTION TIMEOUT when timeout is set lower than server response time', function(done) {
+      http.use(proxy('http://localhost:8080', {
+        connectTimeout: 100,
+        timeout: 300,
+      }));
+
+      assertConnectionTimeout(http, 300, done);
+    });
+
+    it('should fail with CONNECTION TIMEOUT based on connectTimeout when a connection cannot be made', function(done) {
+      http.use(proxy('http://127.0.0.0', {
+        connectTimeout: 100,
+        timeout: 300,
+      }));
+
+      assertConnectionTimeout(http, 100, done);
+    });
+
+    it('should succeed when timeout is higher than server response time', function(done) {
+      http.use(proxy('http://localhost:8080', {
+        connectTimeout: 100,
+        timeout: 1200,
+      }));
+
+      assertSuccess(http, done);
+    });
+  });
+
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -14,6 +14,7 @@ declare namespace koaHttpProxy {
     preserveReqSession?: boolean,
     reqAsBuffer?: boolean,
     reqBodyEncoding?: string | null,
+    connectTimeout?: number,
     timeout?: number,
     filter?(ctx: koa.Context): boolean,
     proxyReqBodyDecorator?(bodyContent: string, ctx: koa.Context): string | Promise<string>,


### PR DESCRIPTION
This adds a new option to supply a separate timeout for a connection to be made. This allows you to fail fast if there are dns or network issues if you need a longer timeout in general (or don't want to set a timeout at all)