### PR TITLE
Support passing an http(s).Agent option:

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ If you wish to proxy only specific paths, you can use a router middleware to acc
 
 ### Options
 
+#### agent
+
+Use a custom `http.Agent` for proxy requests.
+
+```js
+var agent = new http.Agent(options);
+app.use(proxy('www.google.com', {
+  agent: agent,
+}));
+```
+
 #### port
 
 The port to use for the proxied host.

--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -75,6 +75,10 @@ function createRequestOptions(ctx, options) {
     reqOpt.session = ctx.session;
   }
 
+  if (options.agent) {
+    reqOpt.agent = options.agent;
+  }
+
   return Promise.resolve(reqOpt);
 }
 

--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -15,6 +15,7 @@ function resolveOptions(options) {
   options = options || {};
 
   return {
+    agent: options.agent,
     proxyReqPathResolver:  options.proxyReqPathResolver,
     proxyReqOptDecorator: options.proxyReqOptDecorator,
     proxyReqBodyDecorator: options.proxyReqBodyDecorator,

--- a/test/agent.js
+++ b/test/agent.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var Koa = require('koa');
+var agent = require('supertest').agent;
+var proxy = require('../');
+var http = require('http');
+
+describe('agent', function() {
+  'use strict';
+
+  this.timeout(10000);
+
+  it('agent', function(done) {
+    var httpAgent = new http.Agent();
+    var app = new Koa();
+    app.use(proxy('httpbin.org', {
+      agent: httpAgent,
+      proxyReqOptDecorator: function(reqOpts, ctx) {
+        assert(reqOpts.agent, httpAgent);
+        return ctx;
+      }
+    }));
+
+    agent(app.callback())
+      .get('/user-agent')
+      .end(function(err) {
+        if (err) { return done(err); }
+        done();
+      });
+  });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,6 +5,7 @@ declare function koaHttpProxy(host: string, options: koaHttpProxy.IOptions): koa
 
 declare namespace koaHttpProxy {
   export interface IOptions {
+    agent?: Agent,
     headers?: { [key: string]: any },
     strippedHeaders?: [string],
     https?: boolean,


### PR DESCRIPTION
This is particularly useful to be able to do connection pooling.

cc @nsimmons @jgodson 

@ragalie verified working as expected.