### PR TITLE
Don't set Connection: close by default

### DIFF
--- a/lib/requestOptions.js
+++ b/lib/requestOptions.js
@@ -56,10 +56,7 @@ function reqHeaders(ctx, options) {
   if (!options.preserveHostHdr) {
     skipHdrs.push('host');
   }
-  var hds = extend(headers, ctx.headers, skipHdrs);
-  hds.connection = 'close';
-
-  return hds;
+  return extend(headers, ctx.headers, skipHdrs);
 }
 
 function createRequestOptions(ctx, options) {

--- a/test/headers.js
+++ b/test/headers.js
@@ -18,6 +18,27 @@ describe('proxies headers', function() {
     }));
   });
 
+  it('does not include connection header by default', function(done) {
+    var app = new Koa();
+    app.use(proxy('httpbin.org', {
+      proxyReqOptDecorator: function(reqOpts, ctx) {
+        try {
+          assert(!reqOpts.headers.connection);
+        } catch (err) {
+          done(err);
+        }
+        return ctx;
+      }
+    }));
+
+    agent(app.callback())
+      .get('/user-agent')
+      .end(function(err) {
+        if (err) { return done(err); }
+        done();
+      });
+  });
+
   it('passed as options', function(done) {
     agent(http.callback())
       .get('/headers')


### PR DESCRIPTION
With this as the default it's not obvious why connection pooling fails to work.