### PR TITLE
Fix reference to Agent type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -5,7 +5,7 @@ declare function koaHttpProxy(host: string, options: koaHttpProxy.IOptions): koa
 
 declare namespace koaHttpProxy {
   export interface IOptions {
-    agent?: Agent,
+    agent?: http.Agent,
     headers?: { [key: string]: any },
     strippedHeaders?: [string],
     https?: boolean,


### PR DESCRIPTION
Closes: https://github.com/nsimmons/koa-better-http-proxy/issues/31

Fixes the reference to the `Agent` type, which was available on `http`.