### PR TITLE
Prevent headers leaking across requests

### DIFF
--- a/lib/resolveOptions.js
+++ b/lib/resolveOptions.js
@@ -25,7 +25,7 @@ function resolveOptions(options) {
     // For backwards compatability, we default to legacy behavior for newly added settings.
     parseReqBody: isUnset(options.parseReqBody) ? true : options.parseReqBody,
     reqBodyEncoding: resolveBodyEncoding(options.reqBodyEncoding),
-    headers: options.headers,
+    headers: {...options.headers || {}},
     strippedHeaders: options.strippedHeaders,
     preserveReqSession: options.preserveReqSession,
     https: options.https,

--- a/test/integration/proxyReqPathResolver.js
+++ b/test/integration/proxyReqPathResolver.js
@@ -28,6 +28,19 @@ describe('resolveProxyReqPath', function() {
     server.close();
   });
 
+  it('does not pollute global proxy headers with individual request headers', function(done) {
+    var app = new Koa();
+    var opts = {headers: {}};
+    app.use(proxy('localhost:12345', opts));
+
+    agent(app.callback())
+      .get('/working')
+      .end(() => {
+        assert.deepStrictEqual(opts.headers, {});
+        done();
+      })
+  });
+
   describe('when author uses option proxyReqPathResolver', function() {
     it('the proxy request path is the result of the function', function(done) {
       var app = new Koa();


### PR DESCRIPTION
In `reqOptions.js`, there's an `extend` that merges the current request's headers into the proxy's `headers` config:

```
function reqHeaders(ctx, options) {
  var headers = options.headers || {};

  var skipHdrs = [ 'connection', 'content-length' ];
  if (!options.preserveHostHdr) {
    skipHdrs.push('host');
  }
  return extend(headers, ctx.headers, skipHdrs);
}
```

In my scenario, this is a problem because my HTML requests don't set a `content-type`, but my JSON requests do.  So:
* HTML requests are fine at first
* Then my server receives a JSON request (with `content-type: application/json`)
* The proxy's global header config now contains `content-type: application/json`
* ... which is then merged into any HTML requests that don't have an explicit content-type
