### PR TITLE
StrippedHeaders type does not allow multiple headers.

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -7,7 +7,7 @@ declare namespace koaHttpProxy {
   export interface IOptions {
     agent?: http.Agent,
     headers?: { [key: string]: any },
-    strippedHeaders?: [string],
+    strippedHeaders?: string[],
     https?: boolean,
     limit?: string,
     parseReqBody?: boolean,


### PR DESCRIPTION
### Problem statement
The `strippedHeaders` type declared in `types.d.ts` was set to allow only one header to be stripped.

### Resolution
I have updated the type of `strippedHeaders` from `[string]` to `string[]`.