### PR TITLE
fix: types definition on proxy function can accept a function as first parameter

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,7 @@
 import * as koa from 'koa';
 import * as http from 'http';
 
-declare function koaHttpProxy(host: string, options: koaHttpProxy.IOptions): koa.Middleware;
+declare function koaHttpProxy(host: string | ((ctx: koa.Context) => string), options: koaHttpProxy.IOptions): koa.Middleware;
 
 declare namespace koaHttpProxy {
   export interface IOptions {


### PR DESCRIPTION
The proxy function can accept the host as a string or as a function that, given the koa context, returns a string.

In the types.d.ts file the function accepts only a string, and this doesn't permit to use the feature in typescript.